### PR TITLE
バリデーション追加: エリア・チーム設定の必須条件

### DIFF
--- a/app/(tabs)/(stacks)/PrisonAreaScreen.tsx
+++ b/app/(tabs)/(stacks)/PrisonAreaScreen.tsx
@@ -64,6 +64,12 @@ function PrisonAreaScreen({ _userStore, _tagGameStore }: Props) {
                 return;
               }
 
+              // バリデーション: 3点未満ならエラー
+              if (tagGameStore.getTagGame().getPrisonArea().length < 3) {
+                Alert.alert("エラー", "監獄エリアは3点以上設定してください。");
+                return;
+              }
+
               const tagGame = tagGameStore.getTagGame();
               if (_.isEmpty(tagGame.getGameMasterId())) {
                 tagGame.setGameMasterId(userStore.getCurrentUser().getId());

--- a/app/(tabs)/(stacks)/TeamEditScreen.tsx
+++ b/app/(tabs)/(stacks)/TeamEditScreen.tsx
@@ -362,15 +362,19 @@ function SettingScreen({ _userStore, _tagGameStore }: Props) {
                 >
                   <TouchableOpacity
                     onPress={async () => {
+                      // バリデーション: 泥棒(生)と警察が各1人以上いないとエラー
+                      const liveCount = tagGameStore.getTagGame().getLiveUsers().length;
+                      const policeCount = tagGameStore.getPoliceUsers().length;
+                      if (liveCount < 1 || policeCount < 1) {
+                        Alert.alert("エラー", "泥棒(生)と警察が各1人以上必要です。");
+                        return;
+                      }
                       if (tagGameStore.getShouldShowGameExplanation()) {
                         router.replace("/GameTimeScreen");
                         return;
                       }
-
                       setSelectedUsers([]);
                       try {
-                        // TODO: 先にエリアを設定しないとidが設定されず、dynamo not keyエラーが発生してしまう
-                        // idはマップコンポーネントではなくて設定画面でゲーム生成ボタンなどの押下時に格納するよう変更する
                         await putTagGames(tagGameStore.getTagGame().toObject());
                         tagGameStore.setIsEditTeams(true);
                       } catch (error) {

--- a/app/(tabs)/(stacks)/ValidAreaScreen.tsx
+++ b/app/(tabs)/(stacks)/ValidAreaScreen.tsx
@@ -62,13 +62,18 @@ function ValidAreaScreen({ _userStore, _tagGameStore }: Props) {
                 return;
               }
 
+              // バリデーション: 3点未満ならエラー
+              if (tagGameStore.getTagGame().getValidAreas().length < 3) {
+                Alert.alert("エラー", "有効エリアは3点以上設定してください。");
+                return;
+              }
+
               const tagGame = tagGameStore.getTagGame();
               if (_.isEmpty(tagGame.getGameMasterId())) {
                 tagGame.setGameMasterId(userStore.getCurrentUser().getId());
               }
 
               await putTagGames(tagGame.toObject());
-              // setIsSetDoneArea(true);
               tagGameStore.setIsSetValidAreaDone(true);
             }}
           >


### PR DESCRIPTION
- 有効エリア・監獄エリアは3点以上でないと登録不可、エラーメッセージ表示
- チーム確定時、泥棒(生)・警察が各1人以上いないと確定不可、エラーメッセージ表示
- 要件定義に基づくバリデーション実装
